### PR TITLE
Fix Pressable properties type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import type {
   FlatListProps,
   VirtualizedListProps,
   ScrollViewProps,
+  PressableProps as NativePressableProps,
 } from 'react-native';
 
 import {
@@ -44,7 +45,7 @@ interface HoverableProps extends ViewProps {
     | ((state: { hovered: boolean }) => React.ReactNode);
 }
 
-interface PressableProps extends Omit<ViewProps, 'style'> {
+interface PressableProps extends Omit<NativePressableProps, 'style'> {
   children: ChildrenType;
   style?: StylesType;
 }


### PR DESCRIPTION
Pressable Props type extends React Native View Props, but the actual component used is a React Native Pressable. This results in TypeScript warnings on if you use Pressable props. The Pressable Props is now changed to extend React Native Pressable Props.